### PR TITLE
fix: entity-extraction polygon definition patch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@ Please delete options that are not relevant.
 Please describe the tests that you ran to verify your changes.
 - [ ] I have validated my schema changes against existing examples.
 - [ ] I have added a new example record for my new schema.
+- [ ] I have incorporated one or more new tests.
 
 **Test Configuration**:
 * Operating System:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,15 +22,11 @@ Please describe the tests that you ran to verify your changes.
 **Test Configuration**:
 * Operating System:
 * Toolchain:
-* SDK:
 
 ## Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published in downstream modules

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Open Validation Schemas** is a collection of strict, versioned JSON schemas for defining and validating structured metadata.
 
-It provides a **unified contract** for many common data engineering tasks, standardizing outputs from diverse sources—including **machine learning models**, **workflow steps**, **human-in-the-loop annotation**, and **ad-hoc scripts**.
+It provides a **unified contract** for many common data engineering tasks, standardizing outputs from a range of sources, including **machine learning models**, **workflow steps**, **annotation tasks**, and **ad-hoc scripts**.
 
 These schemas are designed as a standalone open standard to decouple data producers from downstream consumers. They are used in production by [DorsalHub](https://dorsalhub.com) to structure and validate user-contributed file annotations.
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -88,7 +88,24 @@ Example:
 }
 ```
 
+### 3. Language Constraints
 
-### 3. Exceptions
+We strictly support the [JSON Schema 2020](https://json-schema.org/draft/2020-12/json-schema-core) specification, and thus all schemas must include `"$schema": "https://json-schema.org/draft/2020-12/schema"` in their root. 
+
+While we support the 2020 spec, we specifically disallow specific features of the JSON Schema spec, to ensure schemas are portable, deterministic, and safe:
+
+#### No `default`
+* **Rule:** The `default` keyword is forbidden.
+* **Reason:** While `default` is officially defined as an [annotation](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.9.2), allowing it creates ambiguity between different validators. Some tools treat it as an annotation, while others treat it as a [transformation directive](https://ajv.js.org/guide/modifying-data.html#assigning-defaults) (e.g. injecting the value if missing). To avoid ambiguity, we forbid the keyword.
+
+#### No External Dependencies (`$ref`)
+* **Rule:** References must be internal (e.g., `#/$defs/name`). References to remote URLs (e.g., `https://example.com/schema.json`) are forbidden.
+* **Reason:** Schemas must be fully self-contained/standalone. Validation must not depend on network availability or external server state.
+
+#### No Dynamic Scope
+* **Rule:** `$dynamicRef` and `$dynamicAnchor` are forbidden.
+* **Reason:** Scope resolution must be static and lexically determinable. This ensures schemas can be easily indexed, audited, and translated into other formats (like SQL tables or Avro) without complex runtime evaluation.
+
+### 4. Exceptions
 
 - :`open/geolocation`**: This schema implements a subset of GeoJSON ([RFC 7946](https://datatracker.ietf.org/doc/html/rfc7946){:target="_blank"}). For this reason it does not include the `attributes` field, as GeoJSON already defines `properties` with a similar function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-validation-schemas"
-version = "0.1.1"
+version = "0.1.2"
 description = "DorsalHub Open Validation Schemas CI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/schemas/audio-transcription.json
+++ b/schemas/audio-transcription.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/audio-transcription",
     "title": "Audio Transcription",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Store text transcribed from an audio source. Supports timed segments, speaker identification, and non-verbal events.",
     "type": "object",
     "properties": {

--- a/schemas/classification.json
+++ b/schemas/classification.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/classification",
     "title": "File Classification",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Represent the result of a classification. Supports predicted labels, confidence scores, and vocabulary.",
     "type": "object",
     "properties": {

--- a/schemas/document-extraction.json
+++ b/schemas/document-extraction.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/document-extraction",
     "title": "Document Extraction",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Represent the layout and content of a document, including text blocks, geometric coordinates, and page structure.",
     "type": "object",
     "properties": {

--- a/schemas/embedding.json
+++ b/schemas/embedding.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/embedding",
     "title": "Embedding",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Store a vector and (optionally) the algorithm or embedding model which generated it.",
     "type": "object",
     "properties": {

--- a/schemas/entity-extraction.json
+++ b/schemas/entity-extraction.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/entity-extraction",
     "title": "Entity Extraction",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Represent named entities, structural slots, or visual concepts extracted from unstructured data. Links raw evidence (text spans or geometric regions) to normalized values and business concepts.",
     "type": "object",
     "properties": {
@@ -184,7 +184,8 @@
                                                 "required": [
                                                     "x",
                                                     "y"
-                                                ]
+                                                ],
+                                                "additionalProperties": false
                                             }
                                         }
                                     },

--- a/schemas/generic.json
+++ b/schemas/generic.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/generic",
     "title": "Generic",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "A flexible schema for storing arbitrary key-value data.",
     "type": "object",
     "properties": {

--- a/schemas/geolocation.json
+++ b/schemas/geolocation.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/geolocation",
     "title": "Geolocation",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Represent a geographic feature. Defines a subset of GeoJSON (RFC 7946) optimized for predictable parsing and indexing. It restricts the root to a single 'Feature', supports all fixed-depth geometries (Point, Polygon, Multi-types), and enforces flat properties to prevent recursion and nesting attacks.",
     "type": "object",
     "properties": {

--- a/schemas/llm-output.json
+++ b/schemas/llm-output.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/llm-output",
     "title": "LLM Output",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Store a single interaction with an LLM (a Prompt/Response pair). Captures the input prompt, the resulting output, and the configuration parameters used at that moment.",
     "type": "object",
     "properties": {

--- a/schemas/object-detection.json
+++ b/schemas/object-detection.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/object-detection",
     "title": "Object Detection",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Represent objects detected within a source. Supports bounding boxes, polygons, hierarchical relationships, and confidence scores.",
     "type": "object",
     "properties": {

--- a/schemas/regression.json
+++ b/schemas/regression.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/regression",
     "title": "Regression",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Represent continuous numerical predictions. Supports point estimates, confidence intervals, and time-series forecasting.",
     "type": "object",
     "properties": {

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -7,6 +7,7 @@ REPO_ROOT = Path(__file__).parent.parent
 SCHEMAS_DIR = REPO_ROOT / "schemas"
 EXAMPLES_DIR = REPO_ROOT / "examples"
 POSITIVE_DIR = EXAMPLES_DIR / "positive"
+NEGATIVE_DIR = EXAMPLES_DIR / "negative"
 
 
 def get_schemas():
@@ -36,3 +37,78 @@ def get_covered_schemas():
             if p.name.startswith(schema_name):
                 covered.add(schema_name)
     return covered
+
+
+def iter_nodes(schema, path=""):
+    """Recursively yield (path, node) for every node in the schema."""
+    if isinstance(schema, dict):
+        yield path, schema
+        for k, v in schema.items():
+            yield from iter_nodes(v, path=f"{path}/{k}")
+    elif isinstance(schema, list):
+        for i, item in enumerate(schema):
+            yield from iter_nodes(item, path=f"{path}[{i}]")
+
+@pytest.mark.parametrize("filename, schema", get_schemas())
+def test_schema_adheres_to_style_guide(filename, schema):
+    """
+    Enforces the 'Strict by Default' policy.
+    Now strictly checks maxLength even for formatted strings.
+    """
+    errors = []
+    
+    # EXCEPTION: Geolocation is allowed to be open per Style Guide
+    # (But we still check it for other rules like maxLength!)
+    is_geolocation = (filename == "geolocation.json")
+
+    for path, node in iter_nodes(schema):
+        if not isinstance(node, dict):
+            continue
+
+        # Skip Logic Blocks for structural checks (strictness here breaks composition)
+        if any(k in path for k in ["/if", "/then", "/else", "/not", "/oneOf", "/anyOf", "/allOf"]):
+            continue
+
+        # 1. Ban 'default' (Behavioral Ambiguity)
+        if "default" in node:
+            errors.append(f"{path}: The keyword 'default' is forbidden.")
+
+        # 2. Ban Remote References (Standalone Promise)
+        if "$ref" in node:
+            ref = node["$ref"]
+            if ref.startswith("http") or ref.startswith("//"):
+                errors.append(f"{path}: Remote $ref '{ref}' is forbidden. Use internal #/$defs.")
+
+        # 3. Enforce Bounds on Strings (No Unbounded Structures)
+        if node.get("type") == "string" and "enum" not in node and "const" not in node:
+            if "maxLength" not in node:
+                 errors.append(f"{path}: String must have 'maxLength' (even if format is set).")
+
+        # 4. Enforce Bounds on Arrays
+        if node.get("type") == "array":
+            if "maxItems" not in node:
+                errors.append(f"{path}: Array must have 'maxItems'.")
+
+        # 5. strict additionalProperties
+        # Skip this check for geolocation.json (it is explicitly open)
+        if not is_geolocation and "properties" in node and "attributes" not in path:
+             if node.get("additionalProperties") is not False:
+                  errors.append(f"{path}: Object must set 'additionalProperties': false.")
+
+    if errors:
+        pytest.fail(f"Schema '{filename}' violates Style Guide:\n" + "\n".join(errors))
+
+
+def test_every_schema_has_negative_examples():
+    """Ensure every schema has at least one invalid example to prove constraints work."""
+    schema_names = get_schema_names()
+    covered = set()
+    
+    for p in NEGATIVE_DIR.glob("*.json"):
+        for name in schema_names:
+            if p.name.startswith(name):
+                covered.add(name)
+    
+    missing = schema_names - covered
+    if missing:
+        pytest.fail(f"The following schemas have NO negative examples: {missing}")

--- a/uv.lock
+++ b/uv.lock
@@ -57,7 +57,7 @@ wheels = [
 
 [[package]]
 name = "open-validation-schemas"
-version = "0.1.1"
+version = "0.1.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Description

- **fix**: `entity-extraction` polygon definition previously allowed arbitrary fields.
- **testing**: New integration tests which would have caught the `entity-extraction` polygon issue.
- **docs**: New section in **`STYLE_GUIDE.md`** mentioning previously undocumented constraints regarding JSON Schema keywords that are explicitly **not** supported (e.g. `default`, `$dynamicRef`, `$dynamicAnchor`)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] I have validated my schema changes against existing examples.
- [x] I have incorporated one or more new tests.

**Test Configuration**:
* Operating System: Ubuntu 24.04
* Toolchain: uv + pytest

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Fixes #3 