### PR TITLE
feat: duration in audio-transcription

### DIFF
--- a/examples/negative/audio-transcription-negative-duration.json
+++ b/examples/negative/audio-transcription-negative-duration.json
@@ -1,0 +1,13 @@
+{
+  "track_id": 1,
+  "language": "eng",
+  "duration": -15.5,
+  "text": "This record contains a negative duration, which must be rejected by the schema.",
+  "segments": [
+    {
+      "text": "This record contains a negative duration...",
+      "start_time": 0.0,
+      "end_time": 2.5
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-validation-schemas"
-version = "0.3.0"
+version = "0.4.0"
 description = "DorsalHub Open Validation Schemas CI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/schemas/audio-transcription.json
+++ b/schemas/audio-transcription.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/audio-transcription",
     "title": "Audio Transcription",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Store text transcribed from an audio source. Supports timed segments, speaker identification, and non-verbal events.",
     "type": "object",
     "properties": {
@@ -29,6 +29,11 @@
             "description": "The 3-letter ISO-639-3 language code of the transcription (e.g., 'eng', 'fra').",
             "pattern": "^[a-z]{3}$",
             "maxLength": 3
+        },
+        "duration": {
+            "type": "number",
+            "description": "The total duration of the source media in seconds.",
+            "minimum": 0
         },
         "score_explanation": {
             "type": "string",

--- a/schemas/classification.json
+++ b/schemas/classification.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/classification",
     "title": "File Classification",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Represent the result of a classification. Supports predicted labels, confidence scores, and vocabulary.",
     "type": "object",
     "properties": {

--- a/schemas/document-extraction.json
+++ b/schemas/document-extraction.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/document-extraction",
     "title": "Document Extraction",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Represent the layout and content of a document, including text blocks, geometric coordinates, and page structure.",
     "type": "object",
     "properties": {

--- a/schemas/embedding.json
+++ b/schemas/embedding.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/embedding",
     "title": "Embedding",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Store a vector and (optionally) the algorithm or embedding model which generated it. Supports both array (dense) and object (sparse) representations.",
     "type": "object",
     "properties": {

--- a/schemas/entity-extraction.json
+++ b/schemas/entity-extraction.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/entity-extraction",
     "title": "Entity Extraction",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Represent named entities, structural slots, or visual concepts extracted from unstructured data. Links raw evidence (text spans or geometric regions) to normalized values and business concepts.",
     "type": "object",
     "properties": {

--- a/schemas/generic.json
+++ b/schemas/generic.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/generic",
     "title": "Generic",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "A flexible schema for storing arbitrary key-value data.",
     "type": "object",
     "properties": {

--- a/schemas/geolocation.json
+++ b/schemas/geolocation.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/geolocation",
     "title": "Geolocation",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Represent a geographic feature. Defines a subset of GeoJSON (RFC 7946) optimized for predictable parsing and indexing. It restricts the root to a single 'Feature', supports all fixed-depth geometries (Point, Polygon, Multi-types), and enforces flat properties to prevent recursion and nesting attacks.",
     "type": "object",
     "properties": {

--- a/schemas/llm-output.json
+++ b/schemas/llm-output.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/llm-output",
     "title": "LLM Output",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Store a single interaction with an LLM (a Prompt/Response pair). Captures the input prompt, the resulting output, and the configuration parameters used at that moment.",
     "type": "object",
     "properties": {

--- a/schemas/object-detection.json
+++ b/schemas/object-detection.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/object-detection",
     "title": "Object Detection",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Represent objects detected within a source. Supports bounding boxes, polygons, hierarchical relationships, and confidence scores.",
     "type": "object",
     "properties": {

--- a/schemas/regression.json
+++ b/schemas/regression.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/regression",
     "title": "Regression",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Represent continuous numerical predictions. Supports point estimates, confidence intervals, and time-series forecasting.",
     "type": "object",
     "properties": {


### PR DESCRIPTION
## Description

This PR introduces a top-level `duration` field to the `open/audio-transcription` schema, bumping the version of all schemas to **v0.4.0**.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have verified these changes by adding positive and negative examples for the new field and ensuring the internal style guide linter passes.

- [x] I have validated my schema changes against existing examples.
- [x] I have added a new example record (`examples/positive/audio-transcription-with-duration.json`).

**Test Configuration**:
* Operating System: Ubuntu 24.04
* Toolchain: `uv`, `pytest`, `jsonschema-rs`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes