### PR TITLE
feat: document-extraction optional text field and coco features

### DIFF
--- a/examples/negative/document-extraction-bad-missing-text.json
+++ b/examples/negative/document-extraction-bad-missing-text.json
@@ -1,0 +1,10 @@
+{
+  "extraction_type": "text",
+  "blocks": [
+    {
+      "block_type": "text",
+      "id": "missing-text-block",
+      "page_number": 1
+    }
+  ]
+}

--- a/examples/negative/document-extraction-bad-multipolygon-norm.json
+++ b/examples/negative/document-extraction-bad-multipolygon-norm.json
@@ -1,0 +1,17 @@
+{
+  "extraction_type": "polygons",
+  "unit": "normalized",
+  "blocks": [
+    {
+      "block_type": "multi_polygon",
+      "id": "bad-norm-block",
+      "multi_polygon": [
+        [
+          {"x": 0.5, "y": 0.5},
+          {"x": 1.5, "y": 0.5},
+          {"x": 0.5, "y": 0.9}
+        ]
+      ]
+    }
+  ]
+}

--- a/examples/negative/document-extraction-bad-page-width.json
+++ b/examples/negative/document-extraction-bad-page-width.json
@@ -1,0 +1,20 @@
+{
+  "extraction_type": "boxes",
+  "unit": "px",
+  "page_width": [
+    {
+      "value": 850
+    }
+  ],
+  "blocks": [
+    {
+      "block_type": "box",
+      "box": {
+        "x": 10,
+        "y": 10,
+        "width": 100,
+        "height": 100
+      }
+    }
+  ]
+}

--- a/examples/positive/document-extraction-2.json
+++ b/examples/positive/document-extraction-2.json
@@ -1,0 +1,44 @@
+{
+  "extraction_type": "mixed",
+  "unit": "px",
+  "page_width": [
+    { "value": 850, "pages": [1] },
+    { "value": 1100, "pages": [2] }
+  ],
+  "page_height": 1100,
+  "blocks": [
+    {
+      "block_type": "box",
+      "id": "logo-box",
+      "page_number": 1,
+      "box": {
+        "x": 50,
+        "y": 50,
+        "width": 200,
+        "height": 80
+      },
+      "attributes": {
+        "visual_class": "logo"
+      }
+    },
+    {
+      "block_type": "multi_polygon",
+      "id": "occluded-stamp",
+      "page_number": 2,
+      "multi_polygon": [
+        [
+          {"x": 100, "y": 100},
+          {"x": 200, "y": 100},
+          {"x": 200, "y": 150},
+          {"x": 100, "y": 150}
+        ],
+        [
+          {"x": 100, "y": 180},
+          {"x": 200, "y": 180},
+          {"x": 200, "y": 250},
+          {"x": 100, "y": 250}
+        ]
+      ]
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-validation-schemas"
-version = "0.4.0"
+version = "0.5.0"
 description = "DorsalHub Open Validation Schemas CI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/schemas/audio-transcription.json
+++ b/schemas/audio-transcription.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/audio-transcription",
     "title": "Audio Transcription",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Store text transcribed from an audio source. Supports timed segments, speaker identification, and non-verbal events.",
     "type": "object",
     "properties": {

--- a/schemas/classification.json
+++ b/schemas/classification.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/classification",
     "title": "File Classification",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Represent the result of a classification. Supports predicted labels, confidence scores, and vocabulary.",
     "type": "object",
     "properties": {

--- a/schemas/document-extraction.json
+++ b/schemas/document-extraction.json
@@ -211,10 +211,12 @@
                             "properties": {
                                 "x": {
                                     "type": "number",
+                                    "description": "The x-coordinate of a vertex point.",
                                     "minimum": 0
                                 },
                                 "y": {
                                     "type": "number",
+                                    "description": "The y-coordinate of a vertex point.",
                                     "minimum": 0
                                 }
                             },

--- a/schemas/document-extraction.json
+++ b/schemas/document-extraction.json
@@ -37,6 +37,84 @@
                 "per_mille"
             ]
         },
+        "page_width": {
+            "description": "The absolute width of the page(s) in pixels. Can be a single integer for uniform documents, or an array of objects mapping specific widths to page numbers.",
+            "oneOf": [
+                {
+                    "type": "integer",
+                    "minimum": 1,
+                    "title": "Uniform Width"
+                },
+                {
+                    "type": "array",
+                    "title": "Variable Widths",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "value": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "The absolute width in pixels."
+                            },
+                            "pages": {
+                                "type": "array",
+                                "description": "The page numbers (1-indexed) that share this width.",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "required": [
+                            "value",
+                            "pages"
+                        ],
+                        "additionalProperties": false
+                    }
+                }
+            ]
+        },
+        "page_height": {
+            "description": "The absolute height of the page(s) in pixels. Can be a single integer for uniform documents, or an array of objects mapping specific heights to page numbers.",
+            "oneOf": [
+                {
+                    "type": "integer",
+                    "minimum": 1,
+                    "title": "Uniform Height"
+                },
+                {
+                    "type": "array",
+                    "title": "Variable Heights",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "value": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "The absolute height in pixels."
+                            },
+                            "pages": {
+                                "type": "array",
+                                "description": "The page numbers (1-indexed) that share this height.",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "required": [
+                            "value",
+                            "pages"
+                        ],
+                        "additionalProperties": false
+                    }
+                }
+            ]
+        },
         "score_explanation": {
             "type": "string",
             "description": "Defines the meaning of the 'score' field.",
@@ -51,12 +129,13 @@
                 "properties": {
                     "block_type": {
                         "type": "string",
-                        "description": "Defines the nature of this specific block (text, line, box, or polygon).",
+                        "description": "Defines the nature of this specific block (text, line, box, polygon, or multi_polygon).",
                         "enum": [
                             "text",
                             "line",
                             "box",
-                            "polygon"
+                            "polygon",
+                            "multi_polygon"
                         ]
                     },
                     "id": {
@@ -66,7 +145,7 @@
                     },
                     "text": {
                         "type": "string",
-                        "description": "The text content of the block.",
+                        "description": "The text content of the block. Required for text and line block types.",
                         "maxLength": 4096
                     },
                     "line_number": {
@@ -91,23 +170,19 @@
                         "properties": {
                             "x": {
                                 "type": "number",
-                                "minimum": 0,
-                                "description": "The x-coordinate of the top-left corner."
+                                "minimum": 0
                             },
                             "y": {
                                 "type": "number",
-                                "minimum": 0,
-                                "description": "The y-coordinate of the top-left corner."
+                                "minimum": 0
                             },
                             "width": {
                                 "type": "number",
-                                "minimum": 0,
-                                "description": "The width of the box."
+                                "minimum": 0
                             },
                             "height": {
                                 "type": "number",
-                                "minimum": 0,
-                                "description": "The height of the box."
+                                "minimum": 0
                             }
                         },
                         "required": [
@@ -128,13 +203,11 @@
                             "properties": {
                                 "x": {
                                     "type": "number",
-                                    "minimum": 0,
-                                    "description": "The x-coordinate of a vertex point."
+                                    "minimum": 0
                                 },
                                 "y": {
                                     "type": "number",
-                                    "minimum": 0,
-                                    "description": "The y-coordinate of a vertex point."
+                                    "minimum": 0
                                 }
                             },
                             "required": [
@@ -142,6 +215,34 @@
                                 "y"
                             ],
                             "additionalProperties": false
+                        }
+                    },
+                    "multi_polygon": {
+                        "type": "array",
+                        "description": "An array of polygons, useful for representing a single occluded or fragmented block split into multiple visible parts.",
+                        "maxItems": 100,
+                        "items": {
+                            "type": "array",
+                            "minItems": 3,
+                            "maxItems": 100,
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "x": {
+                                        "type": "number",
+                                        "minimum": 0
+                                    },
+                                    "y": {
+                                        "type": "number",
+                                        "minimum": 0
+                                    }
+                                },
+                                "required": [
+                                    "x",
+                                    "y"
+                                ],
+                                "additionalProperties": false
+                            }
                         }
                     },
                     "attributes": {
@@ -168,11 +269,27 @@
                     }
                 },
                 "required": [
-                    "text",
                     "block_type"
                 ],
                 "additionalProperties": false,
                 "allOf": [
+                    {
+                        "if": {
+                            "properties": {
+                                "block_type": {
+                                    "enum": [
+                                        "text",
+                                        "line"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "required": [
+                                "text"
+                            ]
+                        }
+                    },
                     {
                         "if": {
                             "properties": {
@@ -205,6 +322,20 @@
                         "if": {
                             "properties": {
                                 "block_type": {
+                                    "const": "multi_polygon"
+                                }
+                            }
+                        },
+                        "then": {
+                            "required": [
+                                "multi_polygon"
+                            ]
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "block_type": {
                                     "const": "line"
                                 }
                             }
@@ -219,6 +350,11 @@
                                 {
                                     "required": [
                                         "polygon"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "multi_polygon"
                                     ]
                                 }
                             ]
@@ -322,6 +458,20 @@
                                             }
                                         }
                                     }
+                                },
+                                "multi_polygon": {
+                                    "items": {
+                                        "items": {
+                                            "properties": {
+                                                "x": {
+                                                    "maximum": 1
+                                                },
+                                                "y": {
+                                                    "maximum": 1
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -366,6 +516,20 @@
                                             },
                                             "y": {
                                                 "maximum": 1000
+                                            }
+                                        }
+                                    }
+                                },
+                                "multi_polygon": {
+                                    "items": {
+                                        "items": {
+                                            "properties": {
+                                                "x": {
+                                                    "maximum": 1000
+                                                },
+                                                "y": {
+                                                    "maximum": 1000
+                                                }
                                             }
                                         }
                                     }

--- a/schemas/document-extraction.json
+++ b/schemas/document-extraction.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/document-extraction",
     "title": "Document Extraction",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Represent the layout and content of a document, including text blocks, geometric coordinates, and page structure.",
     "type": "object",
     "properties": {

--- a/schemas/document-extraction.json
+++ b/schemas/document-extraction.json
@@ -49,6 +49,7 @@
                     "type": "array",
                     "title": "Variable Widths",
                     "minItems": 1,
+                    "maxItems": 10000,
                     "items": {
                         "type": "object",
                         "properties": {
@@ -61,6 +62,7 @@
                                 "type": "array",
                                 "description": "The page numbers (1-indexed) that share this width.",
                                 "minItems": 1,
+                                "maxItems": 100000,
                                 "items": {
                                     "type": "integer",
                                     "minimum": 1
@@ -88,6 +90,7 @@
                     "type": "array",
                     "title": "Variable Heights",
                     "minItems": 1,
+                    "maxItems": 10000,
                     "items": {
                         "type": "object",
                         "properties": {
@@ -100,6 +103,7 @@
                                 "type": "array",
                                 "description": "The page numbers (1-indexed) that share this height.",
                                 "minItems": 1,
+                                "maxItems": 100000,
                                 "items": {
                                     "type": "integer",
                                     "minimum": 1

--- a/schemas/document-extraction.json
+++ b/schemas/document-extraction.json
@@ -174,18 +174,22 @@
                         "properties": {
                             "x": {
                                 "type": "number",
+                                "description": "The x-coordinate of the top-left corner.",
                                 "minimum": 0
                             },
                             "y": {
                                 "type": "number",
+                                "description": "The y-coordinate of the top-left corner.",
                                 "minimum": 0
                             },
                             "width": {
                                 "type": "number",
+                                "description": "The width of the box.",
                                 "minimum": 0
                             },
                             "height": {
                                 "type": "number",
+                                "description": "The height of the box.",
                                 "minimum": 0
                             }
                         },

--- a/schemas/embedding.json
+++ b/schemas/embedding.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/embedding",
     "title": "Embedding",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Store a vector and (optionally) the algorithm or embedding model which generated it. Supports both array (dense) and object (sparse) representations.",
     "type": "object",
     "properties": {

--- a/schemas/entity-extraction.json
+++ b/schemas/entity-extraction.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/entity-extraction",
     "title": "Entity Extraction",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Represent named entities, structural slots, or visual concepts extracted from unstructured data. Links raw evidence (text spans or geometric regions) to normalized values and business concepts.",
     "type": "object",
     "properties": {

--- a/schemas/generic.json
+++ b/schemas/generic.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/generic",
     "title": "Generic",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "A flexible schema for storing arbitrary key-value data.",
     "type": "object",
     "properties": {

--- a/schemas/geolocation.json
+++ b/schemas/geolocation.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/geolocation",
     "title": "Geolocation",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Represent a geographic feature. Defines a subset of GeoJSON (RFC 7946) optimized for predictable parsing and indexing. It restricts the root to a single 'Feature', supports all fixed-depth geometries (Point, Polygon, Multi-types), and enforces flat properties to prevent recursion and nesting attacks.",
     "type": "object",
     "properties": {

--- a/schemas/llm-output.json
+++ b/schemas/llm-output.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/llm-output",
     "title": "LLM Output",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Store a single interaction with an LLM (a Prompt/Response pair). Captures the input prompt, the resulting output, and the configuration parameters used at that moment.",
     "type": "object",
     "properties": {

--- a/schemas/object-detection.json
+++ b/schemas/object-detection.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/object-detection",
     "title": "Object Detection",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Represent objects detected within a source. Supports bounding boxes, polygons, hierarchical relationships, and confidence scores.",
     "type": "object",
     "properties": {

--- a/schemas/regression.json
+++ b/schemas/regression.json
@@ -7,7 +7,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://dorsalhub.com/schemas/open/regression",
     "title": "Regression",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Represent continuous numerical predictions. Supports point estimates, confidence intervals, and time-series forecasting.",
     "type": "object",
     "properties": {

--- a/uv.lock
+++ b/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "open-validation-schemas"
-version = "0.3.0"
+version = "0.4.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "open-validation-schemas"
-version = "0.4.0"
+version = "0.5.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Introduces enhancements to the `open/document-extraction` schema to better support modern Document AI pipelines, mixed-layout documents, and lossless interoperability with standard computer vision formats (COCO/YOLO).

* **Conditional `text` Requirement:** The `text` field is now only strictly required if the `block_type` is `"text"` or `"line"`. This eliminates the need for dummy data when extracting purely visual elements (like logos or checkboxes) and allows direct ingestion of layout-only model outputs.
* **Fragmented Elements (COCO/YOLO Interoperability):** Added `"multi_polygon"` to the `block_type` enum. This allows a lossless 1:1 mapping from COCO's `segmentation` arrays, supporting single blocks that are visually split or occluded. Root conditional constraints for coordinate maximums (`normalized` and `per_mille`) were updated to enforce validation on this new array structure.
* **Variable Page Dimensions:** Added `page_width` and `page_height` using a `oneOf` property to support either a uniform integer or an array mapping specific dimensions to specific pages (crucial for mixed-orientation documents).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have verified these changes by passing the strict style guide test suite (`test_schema_adheres_to_style_guide`) and ensuring the bounding constraints correctly handle the new `multi_polygon` depth and dimension arrays. 

- [x] I have validated my schema changes against existing examples.
- [x] I have added a new example record for my new schema

**Test Configuration**:
* Operating System: Linux
* Toolchain: `uv`, `pytest`, `jsonschema-rs`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes